### PR TITLE
Fix GitCommit so that it gives identical output to raw input

### DIFF
--- a/src/GitObject.php
+++ b/src/GitObject.php
@@ -154,4 +154,13 @@ abstract class GitObject {
         return $data[1];
     }
 
+    /**
+     * Validates this GitObject that the given SHA-1 matches the data
+     */
+    public function validate() {
+        if ($this->sha === false)
+            throw new \Exception('Validation impossible without stored hash.');
+
+        return ($this->sha == sha1($this->header().$this->data()));
+    }
 }


### PR DESCRIPTION
GitObject gained validate method that can be used to verify the
behavior of any sub-class.

Fixes #4 

I validated this commit by running the new validate method against the whole Wine git repository history. It takes quite long and there are some commits with empty authors that all work now perfectly.
